### PR TITLE
added Readmes to general project, frontend and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# CorrelAid Engage
+
+CorrelAid engage is a tool intended to help with the management of projects that
+are often done with partner organizations. The tools aims to help with the
+organization of the whole project life cycle.  It is currently
+in development and not yet ready for production use.
+
+The main entities in the system tracks are:
+- Projects
+- Partner organizations
+- Project members
+
+In addition the tool aims to offer two different levels of access:
+- Admins: Can create and edit all entities
+- Team Admins: Can create and edit all entities for their team
+
+## Project structure
+
+The project is split into a frontend and a backend. The frontend is a Vue.js app and the backend is a python app using FastAPI. Storage is done in a Postgres database.
+
+To see how to setup the development environment for the frontend and backend see the respective READMEs in the `frontend` and `backend` folders.
+
+## Selected Makefile commands
+
+In this section we only aim to provide a short overview of the most important commands. For a full list of commands see the `Makefile`.
+
+- `make up`: Starts the backend development environment in docker

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,53 @@
+# Engange Backend
+
+The goal of the engage backend is to provide a REST Api that can be sued by the
+engage frontend. The backend is written in python and uses FastAPI as the main
+library to build the REST Api.
+
+For storage the backend assumes a connection to a Postgres instance.
+
+## Dev env setup
+
+1. Go to the backend folder
+
+1. Install with poetry
+
+        poetry install
+
+1. Install pre-commit hooks
+
+        poetry run pre-commit install -c ../.pre-commit-config.yaml
+
+1. To run all pre-commit hooks for all files use
+
+        poetry run pre-commit run -c ../.pre-commit-config.yaml --all-files
+
+    When run for the first time this should configure and run all hooks. The
+    checks from the hooks should pass for a freshly cloned repository.
+
+## Run the backend
+
+To run the backend you need to have a postgres instance running. The easiest
+way to get one is to use docker.
+
+    docker run --name engage-postgres -e POSTGRES_PASSWORD=engage -p 5432:5432 -d postgres
+
+This will start a postgres instance with the password `engage` and expose the
+default port `5432` on the host. The database will be empty and we'll need to run the migrations to create the tables.
+
+    TBD
+
+Before running the backend you need to set the environment variables. The following variables are required:
+
+    CSRF_SECRET=...
+    POSTGRES_USER=postgres
+    POSTGRES_PASSWORD=engage
+    POSTGRES_DB=postgres
+
+The `CSRF_SECRET` is used to sign the CSRF token. It can be any string. The
+`POSTGRES_USER` and `POSTGRES_PASSWORD` are the credentials for the postgres
+instance. The `POSTGRES_DB` is the name of the database to use.
+
+To run the backend use
+
+    poetry run python src/main.py

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,44 +1,46 @@
-# default
+# Engage Frontend
 
-## Project setup
+This is the frontend for the CorrelAid Engage project. It is a Vue.js app using Vite as a bundler. It uses vue-router for routing and vuetify for the UI components.
 
-```
-# yarn
-yarn
+## Dev env setup
 
-# npm
-npm install
+To setup the dev environment you need to have node.js and a package manager
+installed. For the following instructions we assume that you have npm installed.
 
-# pnpm
-pnpm install
-```
+1. Go to the frontend folder
 
-### Compiles and hot-reloads for development
+1. Install dependencies
 
-```
-# yarn
-yarn dev
+        npm install
 
-# npm
-npm run dev
+1. Install pre-commit hooks via the backend folder. See the backend README for
+   details.
 
-# pnpm
-pnpm dev
-```
+## Local deployment
 
-### Compiles and minifies for production
+To run the frontend locally you can use the following command:
 
-```
-# yarn
-yarn build
+    npm run dev
 
-# npm
-npm run build
+This will start a local server on port 3000. You can then access the frontend
+at http://localhost:3000.
 
-# pnpm
-pnpm build
-```
+### Backend
 
-### Customize configuration
+The frontend expects the backend to be available at http://localhost:8000. To
+start the backend locally see the backend README for details. Alternatively you
+can use the docker-compose setup to start the backend. For this you need to
 
-See [Configuration Reference](https://vitejs.dev/config/).
+1. Go to the root folder of the project
+
+1. Start the backend
+
+        docker-compose up
+
+## Selected npm scripts
+
+This section only aims to provide a short overview of the most important
+npm scripts. For a full list of commands see the `package.json`.
+
+- `npm run dev`: Starts the development server
+- `npm run generate-client`: TBD


### PR DESCRIPTION
Added 3 readmes for the entire project, the backend and the frontend. This PR contributes to
#6, #7 and #8.

This covers dev env setup and (current) deployment instructions for frontend and backend. I've included a few design decisions/tech decisions in the descriptions to the extend that I could identify them at this point.

I also wrote a little bit in the overarching background in the general README. but we could maybe include a little more of the goals from our google docs there.

There is no "How to contribute" section yet, as that will only become relevant once development and deployment processes are more mature.

I think we should discuss which essentials to still include in the Readmes at this point, merge those together with tis PR and then extend the READMEs further along with other process enhancements in the future.