### PR TITLE
moved start and stop shellscript commands to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,94 @@
+BACKEND_START_CMD=gunicorn api.app:app --workers=2 --worker-class=uvicorn.workers.UvicornWorker --bind=0.0.0.0:8000 --access-logfile -
+DOCKER_START_CMD_BASE=docker run -d --rm --network engage-network
+
+.PHONY: up
 up:
 	docker compose up --build
+
+.PHONY: alembic-revision
 alembic-revision:
 	docker compose exec api sh -c "python -m alembic revision -m \"$(m)\" --autogenerate --rev-id \"$(rev-id)\""
+
+.PHONY: alembic-upgrade
 alembic-upgrade:
 	docker compose exec api sh -c "python -m alembic upgrade head"
+
+.PHONY: alembic-downgrade
 alembic-downgrade:
 	docker compose exec api sh -c "python -m alembic downgrade -1"
+
+.PHONY: adduser
 adduser:
 	docker compose exec api sh -c "python cli.py adduser $(params)"
 
+.PHONY: test-backend
 test-backend:
 	cd backend && poetry run pytest -v
 
+.PHONY: test-backend-w-db
 test-backend-w-db:
 	cd backend && ENGAGE_BACKEND_TESTS__TEST_DATABASE=true poetry run pytest -v
 
+.PHONY: start-test-db
 start-test-db:
 	docker compose up -d database
 
-migrate:
-	cd backend/src && poetry run python -m alembic upgrade head
-
+.PHONY: stop-test-db
 stop-test-db:
 	docker compose down
 
+.PHONY: lint
 lint:
 	cd backend && poetry run pre-commit run -c ../.pre-commit-config.yaml
 
+.PHONY: lint-all
 lint-all:
 	cd backend && poetry run pre-commit run -c ../.pre-commit-config.yaml --all-files
+
+.PHONY: build-dev-frontend-backend
+build-dev-frontend-backend:
+	docker build --build-arg ENVIRONMENT=PRODUCTION -t engage-api ./backend
+	docker build -t engage-client ./frontend
+
+.PHONY: create-engage-network
+create-engage-network:
+	(test -z $$(docker network ls --filter name=engage-network -q) \
+		&& (docker network create engage-network \
+			|| echo "Creating engage-network docker network failed.")) \
+	|| echo "engage-network already exists"
+
+.PHONY: start-dev-frontend-backend
+start-dev-frontend-backend: create-engage-network
+	${DOCKER_START_CMD_BASE} \
+		--network-alias api \
+		--name engage-api \
+		--env-file .env.dev \
+		--publish 8000:8000 \
+		engage-api:latest sh -c '${BACKEND_START_CMD}' \
+		|| echo "Starting engange-api failed."
+	${DOCKER_START_CMD_BASE} \
+		--network-alias client \
+		--name engage-client \
+		--publish 8080:80 \
+		engage-client:latest \
+		|| echo "Starting engange-client failed."
+
+.PHONY: build-and-start-dev-frontend-backend
+build-and-start-dev-frontend-backend:
+	make build-dev-frontend-backend
+	make start-dev-frontend-backend
+
+.PHONY: start-dev-database
+start-dev-database: create-engage-network
+	${DOCKER_START_CMD_BASE} \
+		--network-alias database \
+		--name engage-database \
+		--env-file .env.dev \
+		postgres:13.2 \
+		|| echo "Starting engange-database failed."
+
+.PHONY: stop-engage-dev-frontend-backend
+stop-engage-dev-frontend-backend:
+	docker stop engage-api || echo "Stopping engage-api failed."
+	docker stop engage-client || echo "Stopping engage-client failed."
+	docker network rm engage-network || echo "Removing engage-network docker network failed."

--- a/README.md
+++ b/README.md
@@ -27,3 +27,48 @@ To see how to setup the development environment for the frontend and backend see
 In this section we only aim to provide a short overview of the most important commands. For a full list of commands see the `Makefile`.
 
 - `make up`: Starts the backend development environment in docker
+
+## Dev Deployment
+
+To make a dev deployment of the backend you need to
+
+1.  Log into the dev server instance
+
+1.  Clone the repository
+
+1.  Go to the project folder and checkout the branch you want to deploy
+
+1.  Make a copy of the `.env` file
+
+        cp .env .env.dev
+
+1.  Update the `.env` file with the desired values. Additionally the following
+    variables for the database need need to be set:
+
+        POSTGRES_USER=
+        POSTGRES_DB=
+        POSTGRES_PASSWORD=
+
+    Their values have to be the same as the ones set for the `ENAGE_BACKEND_DATABASE`
+    environment variables in the same file.
+
+1.  Set up caddy
+
+        TBD
+
+1.  Run the following make command.
+
+        make build-and-start-dev-frontend-backend
+        make start-dev-database
+
+    This will build and start the frontend and backend containers. The backend will run on port `8000` and the frontend on port `8080`.
+
+1.  To apply migrations and create database users execute the following commands inside he backend container.
+
+        python -m alembic upgrade head
+        python cli.py adduser
+
+    Or equivalently outside of a container
+
+        docker exec engage-api python -m alembic upgrade head
+        docker exec engage-api run python cli.py adduser

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,0 @@
-docker build --build-arg ENVIRONMENT=PRODUCTION -t engage-api ./backend
-docker build -t engage-client ./frontend
-docker network create engage-network || echo "Creating engage-network docker network failed."
-docker run -d --rm --env-file .env.dev --network engage-network --network-alias api --name engage-api --publish 8000:8000 engage-api:latest sh -c 'gunicorn api.app:app --workers=2 --worker-class=uvicorn.workers.UvicornWorker --bind=0.0.0.0:8000 --access-logfile -' || echo "Starting engange-api failed."
-docker run -d --rm --network engage-network --network-alias client --name engage-client --publish 8080:80 engage-client:latest || echo "Starting engange-client failed."

--- a/stop.sh
+++ b/stop.sh
@@ -1,3 +1,0 @@
-docker stop engage-api || echo "Stopping engage-api failed."
-docker stop engage-client || echo "Stopping engage-client failed."
-docker network rm engage-network || echo "Removing engage-network docker network failed."


### PR DESCRIPTION
closes #39

I integrated the commands in the makefile and added a bit of deployment instructions to the readme. I think we should still document the caddy setup a little more in the readme, but I suggest we do it as a seperate PR as it does not realate to #39.