### PR TITLE
added docs folder and first docs

### DIFF
--- a/docs/naming_conventions.md
+++ b/docs/naming_conventions.md
@@ -1,0 +1,23 @@
+# Naming conventions
+
+This file contains the naming conventions used in the project.
+We try to stick to the conventions and new pull requests should follow them.
+That being said, there might be some exceptions to naming conventions, especially in older code.
+Naming conventions might have changed/ were established only after some code has been written.
+We should try to update the code to follow the conventions, where simple renaming can be done
+along with other changes, but complicated renaming should be done in dedicated pull requests.
+
+## Singular vs plural
+
+- table names: plural
+- endpoint names: plural
+- model names: singular
+- schema names: singular
+
+## Environment names
+
+We distinguish between the following environments:
+
+- production: the production environment running on a vps
+- development: the development environment running on a vps
+- local: the local development environment running on a local machine

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -1,0 +1,23 @@
+# Project conventions
+
+This file contains some information about the general project conventions aside from the naming conventions.
+For naming conventions see [naming_conventions.md](naming_conventions.md).
+
+## Project structure
+
+The project is split into frontend and backend which have their own folders in the root directory.
+Additionally there is a `docs` folder which contains documentation and a `scripts` folder which contains scripts to
+help with development.
+
+## Frontend
+
+## Backend
+
+- route prefixes for the api should be defined in `backend/src/api/app.py`
+- model FastAPI (version >= 0.95) dependency injection should be used. This means
+  that dependencies should be injected using the type annotation and the `Annotated` type
+  instead of assigning default values to function arguments with `=Depends(...)`.
+- Use standard collections for type hinting where possible, i.e. `list[int]` instead of `List[int]`.
+- Uses `pydantic>=2` as a major dependency.
+- The minimum treatment of enum data should involve the use of `Literal` types. Otherwise its fine to
+  use strings as data types until the need for more stability arises.


### PR DESCRIPTION
Introduces the docs folder and some docs about conventions. 

It already references the `scripts` folder which does not exist yet but I'll also add that soon.